### PR TITLE
[Adress issue #10] Added an option to limit the button's movements to the sides of the screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ floatingButton.addFloatingSubButton(floatingSubButton);
 | startAngle           | int | The starting angle for button disposition | 0 |
 | endAngle             | int | The ending angle for button disposition   | 180 |
 | radius               | int | The distance between the central button and its children | 100(dp) |
-| movementStyle        | MovementStyle | Configures whether the user can or not drag the FloatingMenu around | MovementStyle.FREE |
+| movementStyle        | MovementStyle (Enumerator) | Configures whether the user can or not drag the FloatingMenu around | MovementStyle.FREE |
 | animationType        | AnimationType (Enumerator) | The open/close animation for FloatingMenuButton | AnimationType.EXPAND |
 | openingDuration      | int | The opening duration, in milliseconds, of the animation | 500 |
 | closingDuration      | int | The closing duration, in milliseconds, of the animation | 500 |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ The following XML file specifies the example on the radial gifs :
   app:layout_constraintLeft_toLeftOf="parent"
   app:layout_constraintRight_toRightOf="parent"
   app:layout_constraintTop_toTopOf="parent"
-  floatingMenuActionButton:anchored="false"
   floatingMenuActionButton:animationType="radial"
   floatingMenuActionButton:dispositionEndAngle="360"
   floatingMenuActionButton:dispositionStartAngle="0"
@@ -117,7 +116,7 @@ floatingButton.addFloatingSubButton(floatingSubButton);
 | startAngle           | int | The starting angle for button disposition | 0 |
 | endAngle             | int | The ending angle for button disposition   | 180 |
 | radius               | int | The distance between the central button and its children | 100(dp) |
-| anchored             | boolean | Configures whether the user can or not drag the FloatingMenu around | false |
+| movementStyle        | MovementStyle | Configures whether the user can or not drag the FloatingMenu around | MovementStyle.FREE |
 | animationType        | AnimationType (Enumerator) | The open/close animation for FloatingMenuButton | AnimationType.EXPAND |
 | openingDuration      | int | The opening duration, in milliseconds, of the animation | 500 |
 | closingDuration      | int | The closing duration, in milliseconds, of the animation | 500 |
@@ -152,7 +151,7 @@ floatingButton = (FloatingMenuButton) findViewById(R.id.my_floating_button);
 floatingButton.setStartAngle(0)
         .setEndAngle(360)
         .setAnimationType(AnimationType.EXPAND)
-        .setAnchored(false);
+        .setMovementStyle(MovementStyle.STICKED_TO_SIDES);
 floatingButton.getAnimationHandler()
         .setOpeningAnimationDuration(500)
         .setClosingAnimationDuration(200)
@@ -161,6 +160,5 @@ floatingButton.getAnimationHandler()
         .setClosingInterpolator(new FastOutLinearInInterpolator())
         .shouldFade(true)
         .shouldScale(true)
-        .shouldRotate(false)
-;
+        .shouldRotate(false);
 ```

--- a/floatingmenu/src/main/java/rjsv/floatingmenu/floatingmenubutton/FloatingMenuButton.java
+++ b/floatingmenu/src/main/java/rjsv/floatingmenu/floatingmenubutton/FloatingMenuButton.java
@@ -75,13 +75,29 @@ public class FloatingMenuButton extends FrameLayout implements View.OnTouchListe
         public void run() {
             Animation fadeOut = new AlphaAnimation(1, 0.6f);
             fadeOut.setInterpolator(new AccelerateInterpolator()); //and this
-            fadeOut.setStartOffset(1000);
             fadeOut.setDuration(300);
+            fadeOut.setAnimationListener(new Animation.AnimationListener() {
+                @Override
+                public void onAnimationStart(Animation animation) {
+
+                }
+
+                @Override
+                public void onAnimationEnd(Animation animation) {
+                    floatingMenuButton.setAlpha(0.6f);
+                }
+
+                @Override
+                public void onAnimationRepeat(Animation animation) {
+
+                }
+            });
+
 
             AnimationSet animation = new AnimationSet(false); //change to false
             animation.addAnimation(fadeOut);
-            floatingMenuButton.setAnimation(animation);
-            floatingMenuButton.setAlpha(0.6f);
+            if (!floatingMenuButton.isMenuOpen())
+                floatingMenuButton.startAnimation(animation);
         }
     };
 

--- a/floatingmenu/src/main/java/rjsv/floatingmenu/floatingmenubutton/MovementStyle.java
+++ b/floatingmenu/src/main/java/rjsv/floatingmenu/floatingmenubutton/MovementStyle.java
@@ -1,9 +1,8 @@
 package rjsv.floatingmenu.floatingmenubutton;
 
 /**
- * Created by https://github.com/jdamacena on 01/03/18.
+ * Created by <a href="https://github.com/jdamacena">Junior Damacena</a> on 01/03/18.
  */
-
 public enum MovementStyle {
     /**
      * The button cannot be dragged

--- a/floatingmenu/src/main/java/rjsv/floatingmenu/floatingmenubutton/MovementStyle.java
+++ b/floatingmenu/src/main/java/rjsv/floatingmenu/floatingmenubutton/MovementStyle.java
@@ -1,0 +1,20 @@
+package rjsv.floatingmenu.floatingmenubutton;
+
+/**
+ * Created by https://github.com/jdamacena on 01/03/18.
+ */
+
+public enum MovementStyle {
+    /**
+     * The button cannot be dragged
+     */
+    ANCHORED,
+    /**
+     * The button can only be placed at the sides of the screen
+     */
+    STICKED_TO_SIDES,
+    /**
+     * The button can be placed anywhere
+     */
+    FREE
+}

--- a/sample/src/main/java/com/rjsvieira/floatingmenu/sample/MainActivity.java
+++ b/sample/src/main/java/com/rjsvieira/floatingmenu/sample/MainActivity.java
@@ -42,6 +42,7 @@ public class MainActivity extends Activity {
         fab_2 = (FloatingMenuButton) findViewById(R.id.fab_2);
         fab_2.setStartAngle(0)
                 .setEndAngle(360)
+                .setTransparentAfterMilliseconds(0)
                 .setAnimationType(AnimationType.RADIAL)
                 .setMovementStyle(MovementStyle.FREE);
 

--- a/sample/src/main/java/com/rjsvieira/floatingmenu/sample/MainActivity.java
+++ b/sample/src/main/java/com/rjsvieira/floatingmenu/sample/MainActivity.java
@@ -43,7 +43,7 @@ public class MainActivity extends Activity {
         fab_2.setStartAngle(0)
                 .setEndAngle(360)
                 .setAnimationType(AnimationType.RADIAL)
-                .setMovementStyle(MovementStyle.ANCHORED);
+                .setMovementStyle(MovementStyle.FREE);
 
         fab_2.getAnimationHandler()
                 .setOpeningAnimationDuration(500)

--- a/sample/src/main/java/com/rjsvieira/floatingmenu/sample/MainActivity.java
+++ b/sample/src/main/java/com/rjsvieira/floatingmenu/sample/MainActivity.java
@@ -7,6 +7,7 @@ import android.support.v4.view.animation.FastOutSlowInInterpolator;
 
 import rjsv.floatingmenu.animation.enumerators.AnimationType;
 import rjsv.floatingmenu.floatingmenubutton.FloatingMenuButton;
+import rjsv.floatingmenu.floatingmenubutton.MovementStyle;
 
 public class MainActivity extends Activity {
 
@@ -20,12 +21,14 @@ public class MainActivity extends Activity {
         initUi();
     }
 
-    private void initUi(){
+    private void initUi() {
         fab_1 = (FloatingMenuButton) findViewById(R.id.fab_1);
         fab_1.setStartAngle(0)
                 .setEndAngle(360)
+                .setRadius(200)
                 .setAnimationType(AnimationType.EXPAND)
-                .setAnchored(false);
+                .setMovementStyle(MovementStyle.STICKED_TO_SIDES);
+
         fab_1.getAnimationHandler()
                 .setOpeningAnimationDuration(500)
                 .setClosingAnimationDuration(200)
@@ -34,14 +37,14 @@ public class MainActivity extends Activity {
                 .setClosingInterpolator(new FastOutLinearInInterpolator())
                 .shouldFade(true)
                 .shouldScale(true)
-                .shouldRotate(false)
-        ;
+                .shouldRotate(false);
 
         fab_2 = (FloatingMenuButton) findViewById(R.id.fab_2);
         fab_2.setStartAngle(0)
                 .setEndAngle(360)
                 .setAnimationType(AnimationType.RADIAL)
-                .setAnchored(false);
+                .setMovementStyle(MovementStyle.ANCHORED);
+
         fab_2.getAnimationHandler()
                 .setOpeningAnimationDuration(500)
                 .setClosingAnimationDuration(200)
@@ -50,8 +53,7 @@ public class MainActivity extends Activity {
                 .setClosingInterpolator(new FastOutLinearInInterpolator())
                 .shouldFade(true)
                 .shouldScale(true)
-                .shouldRotate(false)
-        ;
+                .shouldRotate(false);
 
     }
 }


### PR DESCRIPTION
Hello, I was in need of a way to limit the places where the button could be placed, I wanted it to "stick" to the sides of the screen, so that the subbuttons would show in a nice way. Unfortunately, there wasn't any, then, I created one. I also added an option that make the button get transparent after some time, useful in my app. And here is the result, I hope it helps somebody else 😄 
Edit: I also replaced the `anchored`, by an enumerator called movementStyle that allows to select among `stick to sides`, `anchored` or `free` (wich is equivalent to anchored = false).